### PR TITLE
Update order-contracts submodule and references.

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,11 +1,11 @@
 version: v1
 plugins:
   - name: go
-    out: pkg/api
+    out: pkg/api/io
     opt:
       - paths=source_relative
   - name: go-grpc
-    out: pkg/api
+    out: pkg/api/io
     opt:
       - paths=source_relative
       - require_unimplemented_servers=false

--- a/buf.yaml
+++ b/buf.yaml
@@ -4,4 +4,4 @@ deps:
   - buf.build/bufbuild/protovalidate
 build:
   roots:
-    - proto_files
+    - proto_files/io

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,7 +10,7 @@ import (
 	"specmatic-order-bff-grpc-go/internal/com/store/order/bff/services"
 	"specmatic-order-bff-grpc-go/internal/com/store/order/bff/utils"
 
-	bff_pb "specmatic-order-bff-grpc-go/pkg/api/in/specmatic/examples/store/order_bff_grpc"
+	bff_pb "specmatic-order-bff-grpc-go/pkg/api/io/specmatic/examples/store/grpc"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"

--- a/internal/com/store/order/bff/handlers/bff_handler.go
+++ b/internal/com/store/order/bff/handlers/bff_handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 	"specmatic-order-bff-grpc-go/internal/com/store/order/bff/services"
-	bff_pb "specmatic-order-bff-grpc-go/pkg/api/in/specmatic/examples/store/order_bff_grpc"
+	bff_pb "specmatic-order-bff-grpc-go/pkg/api/io/specmatic/examples/store/grpc"
 
 	"specmatic-order-bff-grpc-go/internal/com/store/order/bff/utils"
 )

--- a/internal/com/store/order/bff/services/domain_service.go
+++ b/internal/com/store/order/bff/services/domain_service.go
@@ -3,8 +3,8 @@ package services
 import (
 	"context"
 	"fmt"
-	domain_pb "specmatic-order-bff-grpc-go/pkg/api/in/specmatic/examples/store/order_api_grpc"
-	bff_pb "specmatic-order-bff-grpc-go/pkg/api/in/specmatic/examples/store/order_bff_grpc"
+	bff_pb "specmatic-order-bff-grpc-go/pkg/api/io/specmatic/examples/store/grpc"
+	domain_pb "specmatic-order-bff-grpc-go/pkg/api/io/specmatic/examples/store/grpc/order_api"
 
 	"google.golang.org/grpc"
 )


### PR DESCRIPTION
- use `io/specmatic` instead of `in/specmatic`.